### PR TITLE
fix(package): set type to `module`

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -29,7 +29,7 @@
         },
         "..": {
             "name": "@jitsi/react-sdk",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@babel/core": "^7.15.8",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "@jitsi/react-sdk",
     "version": "1.4.0",
     "description": "React SDK for the Jitsi Meet IFrame",
+    "type": "module",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "scripts": {
@@ -23,6 +24,7 @@
         "url": "https://github.com/jitsi/jitsi-meet-web-sdk/issues"
     },
     "homepage": "https://github.com/jitsi/jitsi-meet-web-sdk#readme",
+    "exports": "./lib/index.js",
     "peerDependencies": {
         "react": "16 || 17 || 18",
         "react-dom": "16 || 17 || 18"


### PR DESCRIPTION
This should fix the `MODULE_TYPELESS_PACKAGE_JSON` warning.